### PR TITLE
chore: fix linting in config/redis template

### DIFF
--- a/templates/config.txt
+++ b/templates/config.txt
@@ -42,7 +42,7 @@ const redisConfig: RedisConfig = {
       db: 0,
       keyPrefix: '',
     },
-  }
+  },
 }
 
 export default redisConfig


### PR DESCRIPTION
## Proposed changes

When testing out the Redis 4.0.1 package I noticed a linting error in the config/redis.ts template with a missing comma. This tiny PR adds it.

## Types of changes

N/A

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/redis/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Nothing to add.
