### PR TITLE
fix: remove importHelpers from tsconfig

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -47,7 +47,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            23
+                            24
                         </h5>
                         <p class="card-text">Dependencies</p>
                     </div>
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            November 28th 2020, 8:52:16 am
+                            December 24th 2020, 8:31:40 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"esModuleInterop": true,
 		"skipLibCheck": true,
-		"importHelpers": true,
 		"types": ["@adonisjs/core", "@adonisjs/repl", "@types/node"]
 	}
 }


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Remove `importHelpers` flag from tsconfig to fix the current issue

I've suggested removing this flag because other repositories in the adonis family are not using it
The template project tsconfig also does not use it
Without anything (from core or template) introducing `tslib` as a dependency it has to be a dependency
of `@adons/redis` in order for `importHelpers` to work...
Perhaps the core can be updated to use this flag and then the rest of the projects can opt in, otherwise each project that wants to use it would have to update it's dependencies with `tslib` 

fixes #29

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/redis/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
