### PR TITLE
fix: typo publish config.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"build/providers",
 		"build/src",
 		"build/config.js",
-		"build/config.d.js",
+		"build/config.d.ts",
 		"build/templates",
 		"build/instructions.md"
 	],


### PR DESCRIPTION
Just a typo fix that causes typing issue in the `contract/redis.ts` file of Adonis applications where this file is imported : 

```ts
import type { InferConnectionsFromConfig } from '@adonisjs/redis/build/config'
```
