### PR TITLE
added hmset to ioMethods.ts

### DIFF
--- a/src/ioMethods.ts
+++ b/src/ioMethods.ts
@@ -95,6 +95,7 @@ export const ioMethods = [
   'hvals',
   'hgetall',
   'hexists',
+  'hmset',
   'incrby',
   'incrbyfloat',
   'decrby',

--- a/src/ioMethods.ts
+++ b/src/ioMethods.ts
@@ -95,7 +95,6 @@ export const ioMethods = [
   'hvals',
   'hgetall',
   'hexists',
-  'hmset',
   'incrby',
   'incrbyfloat',
   'decrby',

--- a/src/ioMethods.ts
+++ b/src/ioMethods.ts
@@ -87,6 +87,7 @@ export const ioMethods = [
   'hget',
   'hgetBuffer',
   'hmget',
+  'hmset',
   'hincrby',
   'hincrbyfloat',
   'hdel',

--- a/test/redis.spec.ts
+++ b/test/redis.spec.ts
@@ -308,4 +308,32 @@ test.group('Redis Manager', () => {
 
     await redis.quit('primary')
   })
+
+  test('hmset and hmget', async ({ assert }) => {
+    const app = new Application(__dirname, 'web', {})
+    const redis = new RedisManager(
+      app,
+      {
+        connection: 'primary',
+        connections: {
+          primary: {
+            host: process.env.REDIS_HOST,
+            port: Number(process.env.REDIS_PORT),
+          },
+          cluster: {
+            clusters: clusterNodes,
+          },
+        },
+      },
+      new Emitter(app)
+    ) as unknown as RedisManagerContract
+
+    await redis.hmset('greeting', { hello: 'world' })
+    const greeting = await redis.hmget('greeting', 'hello')
+
+    assert.equal(greeting, 'world')
+
+    await redis.del('greeting')
+    await redis.quit('primary')
+  })
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I'm was trying to test something and ran the following command:

```ts
import { BaseCommand } from "@adonisjs/core/build/standalone";
export default class TestCommand extends BaseCommand {
  /**
   * Command name is used to run the command
   */
  public static commandName = "test:command";

  /**
   * Command description is displayed in the "help" output
   */
  public static description = "";

  public static settings = {
    /**
     * Set the following value to true, if you want to load the application
     * before running the command. Don't forget to call `node ace generate:manifest`
     * afterwards.
     */
    loadApp: true,

    /**
     * Set the following value to true, if you want this command to keep running until
     * you manually decide to exit the process. Don't forget to call
     * `node ace generate:manifest` afterwards.
     */
    stayAlive: false,
  };

  public async run() {
    const { default: Redis } = await import("@ioc:Adonis/Addons/Redis");

    // TS tells me that Redis.hmset exists and everything is typed 
    const result = await Redis.hmset("test:123456:test", { a: "a", b: "b" });

    console.log(result);
  }
}
```

I get the following error:

```bash
  TypeError: Redis.hmset is not a function

   at TestThing.run /Users/u/Documents/GitHub/API/commands/TestCommand.ts:32
   27|    };
   28|
   29|    public async run() {
   30|      const { default: Redis } = await import("@ioc:Adonis/Addons/Redis");
   31|
 ❯ 32|      const result = await Redis.hmset("test:123456:test", { a: "a", b: "b" });
   33|
   34|      console.log(result);
   35|    }
   36|  }
```


Response from @Julien-R44 

hey, can you add your method here and make a PR? 
https://github.com/adonisjs/redis/blob/develop/src/ioMethods.ts
I'll do a release once merged

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/redis/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
