### PR TITLE
Add missing REDIS_PASSWORD env key

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -37,7 +37,7 @@ export async function configure(command: Configure) {
     variables: {
       REDIS_HOST: `Env.schema.string({ format: 'host' })`,
       REDIS_PORT: 'Env.schema.number()',
-      REDIS_PASSWORD: Env.schema.string.optional(),
+      REDIS_PASSWORD: 'Env.schema.string.optional()',
     },
   })
 

--- a/configure.ts
+++ b/configure.ts
@@ -37,6 +37,7 @@ export async function configure(command: Configure) {
     variables: {
       REDIS_HOST: `Env.schema.string({ format: 'host' })`,
       REDIS_PORT: 'Env.schema.number()',
+      REDIS_PASSWORD: Env.schema.string.optional(),
     },
   })
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have installed the [Redis package](https://docs.adonisjs.com/guides/redis) on a blank Adonis 6 project with the API setup.

In the `env.ts` file the `REDIS_PASSWORD` key was not added by the package configuration step, this may be normal as it may be optional.

I would also like to thank you for your quality work on a regular basis 🙂