### PR TITLE
feat: support multiple handlers for a single subscription

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,12 +9,14 @@
 
 import { createError } from '@poppinss/utils'
 
+/** @deprecated */
 export const E_MULTIPLE_REDIS_SUBSCRIPTIONS = createError<[string]>(
   'Cannot subscribe to "%s" channel. Channel already has an active subscription',
   'E_MULTIPLE_REDIS_SUBSCRIPTIONS',
   500
 )
 
+/** @deprecated */
 export const E_MULTIPLE_REDIS_PSUBSCRIPTIONS = createError<[string]>(
   'Cannot subscribe to "%s" pattern. Pattern already has an active subscription',
   'E_MULTIPLE_REDIS_PSUBSCRIPTIONS',

--- a/tests/redis_connection.spec.ts
+++ b/tests/redis_connection.spec.ts
@@ -138,7 +138,7 @@ test.group('Redis connection', () => {
     assert.equal(message, JSON.stringify({ username: 'virk' }))
   })
 
-  test('throw error when subscribing to a channel twice', async ({ cleanup }) => {
+  test('do not throw error when subscribing to a channel twice', async ({ cleanup }) => {
     const connection = new RedisConnection('main', {
       host: process.env.REDIS_HOST,
       port: Number(process.env.REDIS_PORT),
@@ -150,7 +150,7 @@ test.group('Redis connection', () => {
     connection.subscribe('new:user', () => {})
     await pEvent(connection, 'subscription:ready')
     connection.subscribe('new:user', () => {})
-  }).throws('Cannot subscribe to "new:user" channel. Channel already has an active subscription')
+  })
 
   test('subscribe to a pattern and listen for messages', async ({ assert, cleanup }) => {
     const connection = new RedisConnection('main', {
@@ -174,7 +174,7 @@ test.group('Redis connection', () => {
     assert.equal(message.data, JSON.stringify({ username: 'virk' }))
   })
 
-  test('throw error when subscribing to a pattern twice', async ({ cleanup }) => {
+  test('do not throw error when subscribing to a pattern twice', async ({ cleanup }) => {
     const connection = new RedisConnection('main', {
       host: process.env.REDIS_HOST,
       port: Number(process.env.REDIS_PORT),
@@ -187,7 +187,7 @@ test.group('Redis connection', () => {
     await pEvent(connection, 'psubscription:ready')
 
     connection.psubscribe('user:*', () => {})
-  }).throws('Cannot subscribe to "user:*" pattern. Pattern already has an active subscription')
+  })
 
   test('unsubscribe from a channel', async ({ cleanup }) => {
     const connection = new RedisConnection('main', {

--- a/tests/redis_connection.spec.ts
+++ b/tests/redis_connection.spec.ts
@@ -138,7 +138,7 @@ test.group('Redis connection', () => {
     assert.equal(message, JSON.stringify({ username: 'virk' }))
   })
 
-  test('do not throw error when subscribing to a channel twice', async ({ cleanup }) => {
+  test('call all handlers subscribed to a channel', async ({ assert, cleanup }) => {
     const connection = new RedisConnection('main', {
       host: process.env.REDIS_HOST,
       port: Number(process.env.REDIS_PORT),
@@ -147,9 +147,31 @@ test.group('Redis connection', () => {
 
     await pEvent(connection, 'ready')
 
-    connection.subscribe('new:user', () => {})
-    await pEvent(connection, 'subscription:ready')
-    connection.subscribe('new:user', () => {})
+    const [message1] = await Promise.all([
+      new Promise<any>((resolve) => {
+        connection.subscribe('new:user', (message) => {
+          resolve(message)
+        })
+      }),
+      pEvent(connection, 'subscription:ready').then(() => {
+        connection.publish('new:user', JSON.stringify({ username: 'virk' }))
+      }),
+    ])
+
+    assert.equal(message1, JSON.stringify({ username: 'virk' }))
+
+    const [message2] = await Promise.all([
+      new Promise<any>((resolve) => {
+        connection.subscribe('new:user', (message) => {
+          resolve(message)
+        })
+      }),
+      pEvent(connection, 'subscription:ready').then(() => {
+        connection.publish('new:user', JSON.stringify({ username: 'virk' }))
+      }),
+    ])
+
+    assert.equal(message2, JSON.stringify({ username: 'virk' }))
   })
 
   test('subscribe to a pattern and listen for messages', async ({ assert, cleanup }) => {
@@ -174,7 +196,7 @@ test.group('Redis connection', () => {
     assert.equal(message.data, JSON.stringify({ username: 'virk' }))
   })
 
-  test('do not throw error when subscribing to a pattern twice', async ({ cleanup }) => {
+  test('call all handlers subscribed to a pattern', async ({ assert, cleanup }) => {
     const connection = new RedisConnection('main', {
       host: process.env.REDIS_HOST,
       port: Number(process.env.REDIS_PORT),
@@ -183,10 +205,33 @@ test.group('Redis connection', () => {
 
     await pEvent(connection, 'ready')
 
-    connection.psubscribe('user:*', () => {})
-    await pEvent(connection, 'psubscription:ready')
+    const [message1] = await Promise.all([
+      new Promise<any>((resolve) => {
+        connection.psubscribe('user:*', (channel, message) => {
+          resolve({ channel, message })
+        })
+      }),
+      pEvent(connection, 'psubscription:ready').then(() => {
+        connection.publish('user:add', JSON.stringify({ username: 'virk' }))
+      }),
+    ])
 
-    connection.psubscribe('user:*', () => {})
+    assert.equal(message1.channel, 'user:add')
+    assert.equal(message1.message, JSON.stringify({ username: 'virk' }))
+
+    const [message2] = await Promise.all([
+      new Promise<any>((resolve) => {
+        connection.psubscribe('user:*', (channel, message) => {
+          resolve({ channel, message })
+        })
+      }),
+      pEvent(connection, 'psubscription:ready').then(() => {
+        connection.publish('user:add', JSON.stringify({ username: 'virk' }))
+      }),
+    ])
+
+    assert.equal(message2.channel, 'user:add')
+    assert.equal(message2.message, JSON.stringify({ username: 'virk' }))
   })
 
   test('unsubscribe from a channel', async ({ cleanup }) => {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #65 

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows adding multiple handlers to a single channel subscription.
The old API will still work. A new API was added for removing specific handlers without fully unsubscribing from the channel:

```ts
const handler1 = () => { /* ... */ };

// start subscription
await redis.subscribe('users/123', handler1);

const handler2 = () => { /* ... */ }; 

// use the existing subscription
await redis.subscribe('users/123', handler2);

// remove handler1, keep subscription alive
await redis.unsubscribe('users/123', handler1);

// no more handlers for channel, close subscription
await redis.unsubscribe('users/123', handler2);
```

To avoid introducing any breaking changes, the errors in `errors.ts` were marked `@deprecated`, since they are no longer relevant with the introduction of this feature.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
